### PR TITLE
Agregar utilidades HTML y ampliar carga de archivos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,48 @@
-# Repositorio de fórmulas para ETL
+# Repositorio de fórmulas para ETL y análisis de datos
 
-Este repositorio contiene una colección de funciones útiles para analistas de datos.
-Las funciones están escritas en **Python** y permiten cargar datos de diferentes
-formatos, explorar su contenido y realizar tareas básicas de limpieza.
+Este proyecto agrupa funciones reutilizables para manipulación y exploración de 
+datos con **pandas**. Las utilidades están organizadas en el paquete `formulas` y
+se acompañan de algunos notebooks de ejemplo.
+
+## Estructura principal
+
+```
+formulas/
+    excel_utils.py      # Leer y escribir Excel
+    csv_utils.py        # Limpieza y carga de CSV
+    json_utils.py       # Manejo de JSON
+    html_utils.py       # Leer tablas HTML
+    sql_utils.py        # Conexión a bases de datos
+    pandas_transform.py # Transformaciones comunes con pandas
+    estadisticas.py     # Resúmenes y cálculos estadísticos
+    visualizaciones.py  # Gráficos rápidos
+```
+
+Los notebooks de la carpeta `ejemplos` muestran cómo utilizar estas funciones
+para tareas habituales.
 
 ## Instalación
 
 1. Clona este repositorio.
-2. Instala las dependencias en un entorno de Python (se recomienda `virtualenv`).
-   ```bash
-   pip install pandas seaborn matplotlib
-   ```
+2. Instala las dependencias:
 
-## Uso
-
-Importa el módulo `etl_utils` en tus notebooks o scripts y utiliza las funciones
-según el tipo de archivo o la operación que necesites realizar.
-
-```python
-from etl_utils import cargar_csv, nulos, matriz_correlacion
-
-df = cargar_csv('archivo.csv')
-resumen = nulos(df)
-matriz = matriz_correlacion(df, imprimir=True)
+```bash
+pip install -r requirements.txt
 ```
 
-Consulta la documentación dentro de cada función para conocer los parámetros y
-ver ejemplos de uso.
+## Uso rápido
+
+Importa las funciones que necesites desde `formulas`:
+
+```python
+from formulas import cargar_csv, cargar_html, nulos, grafico_lineas
+
+df = cargar_csv("datos.csv")
+resumen = nulos(df)
+grafico_lineas(df, "fecha", "ventas", titulo="Ventas diarias")
+# También puedes cargar tablas HTML
+# tablas = cargar_html("pagina.html")
+```
+
+Consulta cada módulo para obtener más detalles y ejemplos de uso.
 

--- a/ejemplos/analisis_csv.ipynb
+++ b/ejemplos/analisis_csv.ipynb
@@ -1,0 +1,25 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Análisis rápido de un CSV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from formulas import cargar_csv, nulos\n",
+    "df = cargar_csv('datos.csv')\n",
+    "nulos(df)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ejemplos/conexion_sql.ipynb
+++ b/ejemplos/conexion_sql.ipynb
@@ -1,0 +1,26 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Conexión a bases de datos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from formulas import crear_conexion, leer_query\n",
+    "engine = crear_conexion('sqlite:///mi_db.sqlite')\n",
+    "df = leer_query('SELECT * FROM tabla', engine)\n",
+    "df.head()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ejemplos/limpieza_datos.ipynb
+++ b/ejemplos/limpieza_datos.ipynb
@@ -1,0 +1,27 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Limpieza de datos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from formulas import cargar_csv, limpiar_columnas, limpiar_nombres\n",
+    "df = cargar_csv('sucio.csv')\n",
+    "df = limpiar_columnas(df)\n",
+    "df = limpiar_nombres(df)\n",
+    "df.head()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ejemplos/uso_excel.ipynb
+++ b/ejemplos/uso_excel.ipynb
@@ -1,0 +1,25 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ejemplo de uso con Excel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from formulas import leer_excel\n",
+    "df = leer_excel('archivo.xlsx')\n",
+    "df.head()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/etl_utils.py
+++ b/etl_utils.py
@@ -1,78 +1,19 @@
-"""Funciones útiles para tareas de ETL.
+"""Funciones útiles para tareas de ETL (compatibilidad).
 
-Cada función está pensada para trabajar con distintos tipos de entrada y
-facilitar las primeras etapas de exploración y limpieza de datos.
+Este módulo mantiene la interfaz antigua delegando en las funciones del paquete
+`formulas`. Puedes importar directamente desde `formulas` para obtener todas las
+nuevas funcionalidades.
 """
 
 import os
-import pandas as pd
-import seaborn as sns
-import matplotlib.pyplot as plt
-
-
-def cargar_csv(nombre_archivo):
-    """Cargar un archivo CSV y mostrar un resumen inicial.
-
-    Parameters
-    ----------
-    nombre_archivo : str
-        Ruta del archivo CSV.
-    Returns
-    -------
-    pandas.DataFrame
-    """
-    ruta_archivo = os.path.abspath(nombre_archivo)
-    df = pd.read_csv(ruta_archivo)
-    print(f"Archivo CSV cargado: {os.path.basename(ruta_archivo)}")
-    print("\nPrimeras filas del dataset:")
-    print(df.head())
-    print("\nResumen estadístico del DataFrame:")
-    print(df.describe())
-    return df
-
-
-def cargar_json(nombre_archivo):
-    """Cargar un archivo JSON y mostrar un resumen inicial."""
-    ruta_archivo = os.path.abspath(nombre_archivo)
-    df = pd.read_json(ruta_archivo)
-    print(f"Archivo JSON cargado: {os.path.basename(ruta_archivo)}")
-    print("\nPrimeras filas del dataset:")
-    print(df.head())
-    print("\nResumen estadístico del DataFrame:")
-    print(df.describe())
-    return df
-
-
-def cargar_excel(nombre_archivo, hoja=None):
-    """Cargar un archivo Excel.
-
-    Si `hoja` es None se cargará la primera hoja disponible.
-    """
-    ruta_archivo = os.path.abspath(nombre_archivo)
-    if hoja:
-        df = pd.read_excel(ruta_archivo, sheet_name=hoja)
-    else:
-        df = pd.read_excel(ruta_archivo)
-    print(f"Archivo Excel cargado: {os.path.basename(ruta_archivo)}")
-    print("\nPrimeras filas del dataset:")
-    print(df.head())
-    print("\nResumen estadístico del DataFrame:")
-    print(df.describe())
-    return df
-
-
-def cargar_html(fuente):
-    """Cargar tablas desde un archivo o URL HTML."""
-    if fuente.startswith("http://") or fuente.startswith("https://"):
-        dfs = pd.read_html(fuente)
-    else:
-        ruta = os.path.abspath(fuente)
-        dfs = pd.read_html(ruta)
-    print(f"Número de tablas encontradas: {len(dfs)}")
-    for i, df in enumerate(dfs, 1):
-        print(f"\nTabla {i}:")
-        print(df.head())
-    return dfs
+from formulas import (
+    cargar_csv,
+    cargar_json,
+    leer_excel,
+    nulos,
+    describir_columnas,
+    matriz_correlacion,
+)
 
 
 def cargar_archivo(nombre_archivo):
@@ -83,58 +24,5 @@ def cargar_archivo(nombre_archivo):
     if extension == ".json":
         return cargar_json(nombre_archivo)
     if extension in [".xls", ".xlsx"]:
-        return cargar_excel(nombre_archivo)
-    if extension == ".html":
-        return cargar_html(nombre_archivo)[0]
+        return leer_excel(nombre_archivo)
     raise ValueError(f"Formato de archivo no soportado: {extension}")
-
-
-def nulos(df, ordenar_por="Nulos", imprimir=True):
-    """Resumen de valores nulos, porcentaje y valores únicos."""
-    nulos_por_columna = df.isnull().sum()
-    porcentaje = (nulos_por_columna / len(df)) * 100
-    valores_unicos = df.nunique()
-    filas_dup = df.duplicated().sum()
-    resumen = pd.DataFrame({
-        "Nulos": nulos_por_columna,
-        "Porcentaje Nulos": porcentaje.round(2),
-        "Valores únicos": valores_unicos,
-    })
-    resumen.loc["Duplicados"] = [filas_dup, (filas_dup / len(df)) * 100, "N/A"]
-    if ordenar_por in resumen.columns:
-        resumen = resumen.sort_values(by=ordenar_por, ascending=False)
-    if imprimir:
-        print("Número de nulos, porcentaje de nulos y valores únicos:")
-        print(resumen)
-    return resumen
-
-
-def describir_columnas(df, columnas):
-    """Mostrar información resumida de un conjunto de columnas."""
-    for col in columnas:
-        if col not in df.columns:
-            print(f"La columna {col} no existe en el DataFrame")
-            continue
-        print(f"\nColumna: {col} - Tipo de datos: {df[col].dtype}")
-        print(f"Valores nulos: {df[col].isnull().sum()}  -  Valores distintos: {df[col].nunique()}")
-        print("Valores más frecuentes:")
-        top = df[col].value_counts().head(10)
-        for valor, cuenta in top.items():
-            print(f"{valor:<20} {cuenta}")
-
-
-def matriz_correlacion(df, imprimir=False):
-    """Calcular y mostrar la matriz de correlación para columnas numéricas."""
-    df_num = df.select_dtypes(include=["number"])
-    if df_num.shape[1] < 2:
-        print("El DataFrame no tiene suficientes columnas numéricas para calcular la correlación.")
-        return None
-    corr = df_num.corr()
-    if imprimir:
-        print("Matriz de correlación:")
-        print(corr)
-    plt.figure(figsize=(10, 8))
-    sns.heatmap(corr, annot=True, cmap="coolwarm", fmt=".2f", linewidths=0.5)
-    plt.title("Mapa de Calor - Matriz de Correlación")
-    plt.show()
-    return corr

--- a/formulas/__init__.py
+++ b/formulas/__init__.py
@@ -1,0 +1,32 @@
+"""Colección de funciones reutilizables para análisis de datos."""
+
+from .excel_utils import leer_excel, escribir_excel
+from .csv_utils import cargar_csv, limpiar_columnas
+from .json_utils import cargar_json
+from .sql_utils import crear_conexion, leer_query, escribir_df
+from .pandas_transform import combinar, pivotear, limpiar_nombres
+from .estadisticas import nulos, describir_columnas, matriz_correlacion
+from .visualizaciones import grafico_lineas
+from .file_utils import cargar_archivo
+from .html_utils import cargar_html
+
+__all__ = [
+    "leer_excel",
+    "escribir_excel",
+    "cargar_csv",
+    "limpiar_columnas",
+    "cargar_json",
+    "crear_conexion",
+    "leer_query",
+    "escribir_df",
+    "combinar",
+    "pivotear",
+    "limpiar_nombres",
+    "cargar_archivo",
+    "cargar_html",
+    "nulos",
+    "describir_columnas",
+    "matriz_correlacion",
+    "grafico_lineas",
+]
+

--- a/formulas/csv_utils.py
+++ b/formulas/csv_utils.py
@@ -1,0 +1,25 @@
+"""Funciones para trabajar con archivos CSV."""
+
+import os
+import pandas as pd
+
+
+def cargar_csv(nombre_archivo):
+    """Cargar un archivo CSV y mostrar un resumen inicial."""
+    ruta_archivo = os.path.abspath(nombre_archivo)
+    df = pd.read_csv(ruta_archivo)
+    print(f"Archivo CSV cargado: {os.path.basename(ruta_archivo)}")
+    print("\nPrimeras filas del dataset:")
+    print(df.head())
+    print("\nResumen estadístico del DataFrame:")
+    print(df.describe())
+    return df
+
+
+def limpiar_columnas(df):
+    """Eliminar espacios y convertir nombres de columna a minúsculas."""
+    df = df.copy()
+    df.columns = df.columns.str.strip().str.lower()
+    return df
+
+

--- a/formulas/estadisticas.py
+++ b/formulas/estadisticas.py
@@ -1,0 +1,58 @@
+"""Cálculos estadísticos básicos y avanzados."""
+
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+
+
+def nulos(df, ordenar_por="Nulos", imprimir=True):
+    """Resumen de valores nulos, porcentaje y valores únicos."""
+    nulos_por_columna = df.isnull().sum()
+    porcentaje = (nulos_por_columna / len(df)) * 100
+    valores_unicos = df.nunique()
+    filas_dup = df.duplicated().sum()
+    resumen = pd.DataFrame({
+        "Nulos": nulos_por_columna,
+        "Porcentaje Nulos": porcentaje.round(2),
+        "Valores únicos": valores_unicos,
+    })
+    resumen.loc["Duplicados"] = [filas_dup, (filas_dup / len(df)) * 100, "N/A"]
+    if ordenar_por in resumen.columns:
+        resumen = resumen.sort_values(by=ordenar_por, ascending=False)
+    if imprimir:
+        print("Número de nulos, porcentaje de nulos y valores únicos:")
+        print(resumen)
+    return resumen
+
+
+def describir_columnas(df, columnas):
+    """Mostrar información resumida de un conjunto de columnas."""
+    for col in columnas:
+        if col not in df.columns:
+            print(f"La columna {col} no existe en el DataFrame")
+            continue
+        print(f"\nColumna: {col} - Tipo de datos: {df[col].dtype}")
+        print(f"Valores nulos: {df[col].isnull().sum()}  -  Valores distintos: {df[col].nunique()}")
+        print("Valores más frecuentes:")
+        top = df[col].value_counts().head(10)
+        for valor, cuenta in top.items():
+            print(f"{valor:<20} {cuenta}")
+
+
+def matriz_correlacion(df, imprimir=False):
+    """Calcular y mostrar la matriz de correlación para columnas numéricas."""
+    df_num = df.select_dtypes(include=["number"])
+    if df_num.shape[1] < 2:
+        print("El DataFrame no tiene suficientes columnas numéricas para calcular la correlación.")
+        return None
+    corr = df_num.corr()
+    if imprimir:
+        print("Matriz de correlación:")
+        print(corr)
+    plt.figure(figsize=(10, 8))
+    sns.heatmap(corr, annot=True, cmap="coolwarm", fmt=".2f", linewidths=0.5)
+    plt.title("Mapa de Calor - Matriz de Correlación")
+    plt.show()
+    return corr
+
+

--- a/formulas/excel_utils.py
+++ b/formulas/excel_utils.py
@@ -1,0 +1,20 @@
+"""Utilidades para archivos Excel."""
+
+import pandas as pd
+
+
+def leer_excel(ruta_archivo, hoja=None):
+    """Leer un archivo de Excel y devolver un DataFrame."""
+    if hoja:
+        df = pd.read_excel(ruta_archivo, sheet_name=hoja)
+    else:
+        df = pd.read_excel(ruta_archivo)
+    return df
+
+
+def escribir_excel(df, ruta_archivo, hoja="Sheet1"):
+    """Guardar un DataFrame en un archivo de Excel."""
+    with pd.ExcelWriter(ruta_archivo) as writer:
+        df.to_excel(writer, sheet_name=hoja, index=False)
+
+

--- a/formulas/file_utils.py
+++ b/formulas/file_utils.py
@@ -1,0 +1,38 @@
+"""Funciones genéricas para detección de archivos."""
+
+import os
+import pandas as pd
+from .csv_utils import cargar_csv
+from .json_utils import cargar_json
+from .excel_utils import leer_excel
+from .html_utils import cargar_html
+
+
+def cargar_archivo(nombre_archivo):
+    """Cargar un archivo según su extensión."""
+    ruta_archivo = os.path.abspath(nombre_archivo)
+    extension = os.path.splitext(nombre_archivo)[1].lower()
+
+    if extension == ".csv":
+        return cargar_csv(ruta_archivo)
+    if extension == ".json":
+        return cargar_json(ruta_archivo)
+    if extension in [".xls", ".xlsx"]:
+        return leer_excel(ruta_archivo)
+    if extension == ".html":
+        return cargar_html(ruta_archivo)
+    if extension == ".parquet":
+        return pd.read_parquet(ruta_archivo)
+    if extension == ".h5":
+        return pd.read_hdf(ruta_archivo)
+    if extension == ".feather":
+        return pd.read_feather(ruta_archivo)
+    if extension == ".pkl":
+        return pd.read_pickle(ruta_archivo)
+    if extension == ".dta":
+        return pd.read_stata(ruta_archivo)
+    if extension == ".sav":
+        return pd.read_spss(ruta_archivo)
+
+    raise ValueError(f"Formato de archivo no soportado: {extension}")
+

--- a/formulas/html_utils.py
+++ b/formulas/html_utils.py
@@ -1,0 +1,26 @@
+"""Funciones para manejar tablas HTML."""
+
+import os
+import pandas as pd
+
+
+def cargar_html(fuente):
+    """Cargar tablas desde una URL o archivo HTML.
+
+    Devuelve una lista de DataFrames con las tablas encontradas.
+    Imprime un resumen de las tablas cargadas.
+    """
+    if fuente.startswith("http://") or fuente.startswith("https://"):
+        print(f"Cargando tablas desde la URL: {fuente}")
+        dfs = pd.read_html(fuente)
+    else:
+        ruta_archivo = os.path.abspath(fuente)
+        print(f"Cargando tablas desde el archivo: {os.path.basename(ruta_archivo)}")
+        dfs = pd.read_html(ruta_archivo)
+
+    print(f"\nNúmero de tablas encontradas: {len(dfs)}")
+    for i, df in enumerate(dfs):
+        print(f"\nTabla {i + 1}:")
+        print(df.head())
+    return dfs
+

--- a/formulas/json_utils.py
+++ b/formulas/json_utils.py
@@ -1,0 +1,18 @@
+"""Herramientas para archivos JSON."""
+
+import os
+import pandas as pd
+
+
+def cargar_json(nombre_archivo):
+    """Leer un archivo JSON y mostrar un resumen."""
+    ruta_archivo = os.path.abspath(nombre_archivo)
+    df = pd.read_json(ruta_archivo)
+    print(f"Archivo JSON cargado: {os.path.basename(ruta_archivo)}")
+    print("\nPrimeras filas del dataset:")
+    print(df.head())
+    print("\nResumen estadístico del DataFrame:")
+    print(df.describe())
+    return df
+
+

--- a/formulas/pandas_transform.py
+++ b/formulas/pandas_transform.py
@@ -1,0 +1,29 @@
+"""Transformaciones comunes con pandas."""
+
+import pandas as pd
+
+
+def combinar(df1, df2, on, how="inner"):
+    """Realizar merge entre dos DataFrames."""
+    return pd.merge(df1, df2, on=on, how=how)
+
+
+def pivotear(df, index, columns, values, aggfunc="sum"):
+    """Crear tabla dinámica."""
+    tabla = pd.pivot_table(df, index=index, columns=columns, values=values, aggfunc=aggfunc)
+    return tabla.reset_index()
+
+
+def limpiar_nombres(df):
+    """Convertir columnas a formato snake_case."""
+    df = df.copy()
+    df.columns = (
+        df.columns
+        .str.strip()
+        .str.lower()
+        .str.replace(" ", "_")
+        .str.replace(r"[^a-z0-9_]+", "", regex=True)
+    )
+    return df
+
+

--- a/formulas/sql_utils.py
+++ b/formulas/sql_utils.py
@@ -1,0 +1,25 @@
+"""Módulo para trabajar con bases de datos usando SQLAlchemy."""
+
+import pandas as pd
+from sqlalchemy import create_engine
+
+
+def crear_conexion(url):
+    """Crear un motor de conexión a partir de una URL."""
+    engine = create_engine(url)
+    return engine
+
+
+def leer_query(sql, engine):
+    """Ejecutar una consulta y devolver un DataFrame."""
+    with engine.connect() as conn:
+        df = pd.read_sql(sql, conn)
+    return df
+
+
+def escribir_df(df, tabla, engine, if_exists="replace"):
+    """Guardar un DataFrame en la tabla indicada."""
+    with engine.connect() as conn:
+        df.to_sql(tabla, conn, if_exists=if_exists, index=False)
+
+

--- a/formulas/visualizaciones.py
+++ b/formulas/visualizaciones.py
@@ -1,0 +1,15 @@
+"""Funciones para gráficos con matplotlib, seaborn y plotly."""
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+
+def grafico_lineas(df, x, y, titulo=""):
+    """Crear un gráfico de líneas sencillo."""
+    plt.figure(figsize=(8, 4))
+    sns.lineplot(data=df, x=x, y=y)
+    plt.title(titulo)
+    plt.tight_layout()
+    plt.show()
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pandas
+openpyxl
+sqlalchemy
+seaborn
+matplotlib

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="formulas",
+    version="0.1.0",
+    packages=find_packages(),
+    install_requires=[line.strip() for line in open("requirements.txt")],
+)


### PR DESCRIPTION
## Summary
- incluir `html_utils.py` con la función `cargar_html`
- exponer `cargar_html` desde `formulas.__init__`
- ampliar `file_utils.cargar_archivo` para soportar más formatos
- actualizar README con el uso de `cargar_html`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684939370b848322b144172897d9ccb3