### PR TITLE
Incorporate HTML loader and extended file handling

### DIFF
--- a/formulas/__init__.py
+++ b/formulas/__init__.py
@@ -1,6 +1,6 @@
 """Colección de funciones reutilizables para análisis de datos."""
 
-from .excel_utils import leer_excel, escribir_excel
+from .excel_utils import leer_excel, escribir_excel, cargar_excel
 from .csv_utils import cargar_csv, limpiar_columnas
 from .json_utils import cargar_json
 from .sql_utils import crear_conexion, leer_query, escribir_df
@@ -8,9 +8,11 @@ from .pandas_transform import combinar, pivotear, limpiar_nombres
 from .estadisticas import nulos, describir_columnas, matriz_correlacion
 from .visualizaciones import grafico_lineas
 from .file_utils import cargar_archivo
+from .html_utils import cargar_html
 
 __all__ = [
     "leer_excel",
+    "cargar_excel",
     "escribir_excel",
     "cargar_csv",
     "limpiar_columnas",
@@ -22,6 +24,7 @@ __all__ = [
     "pivotear",
     "limpiar_nombres",
     "cargar_archivo",
+    "cargar_html",
     "nulos",
     "describir_columnas",
     "matriz_correlacion",

--- a/formulas/excel_utils.py
+++ b/formulas/excel_utils.py
@@ -1,5 +1,6 @@
 """Utilidades para archivos Excel."""
 
+import os
 import pandas as pd
 
 
@@ -10,6 +11,34 @@ def leer_excel(ruta_archivo, hoja=None):
     else:
         df = pd.read_excel(ruta_archivo)
     return df
+
+
+def cargar_excel(nombre_archivo, hoja=None):
+    """Cargar un archivo de Excel e imprimir un resumen."""
+    try:
+        ruta_archivo = os.path.abspath(nombre_archivo)
+        nombre_archivo_simple = os.path.basename(ruta_archivo)
+        if hoja:
+            df = pd.read_excel(ruta_archivo, sheet_name=hoja)
+        else:
+            df = pd.read_excel(ruta_archivo)
+
+        print(f"Archivo Excel cargado: {nombre_archivo_simple}")
+        print("\nPrimeras filas del dataset:")
+        print(df.head())
+        print("\nResumen estadístico del DataFrame:")
+        print(df.describe())
+        return df
+    except FileNotFoundError:
+        print(
+            f"Error: No se pudo encontrar el archivo '{nombre_archivo_simple}'"
+        )
+    except ValueError:
+        print(
+            f"Error: No se pudo cargar el archivo '{nombre_archivo_simple}'. Verifique si el archivo está en formato Excel válido."
+        )
+    except Exception as e:
+        print(f"Error al cargar el archivo: {str(e)}")
 
 
 def escribir_excel(df, ruta_archivo, hoja="Sheet1"):

--- a/formulas/file_utils.py
+++ b/formulas/file_utils.py
@@ -1,19 +1,36 @@
 """Funciones genéricas para detección de archivos."""
 
 import os
+import pandas as pd
 from .csv_utils import cargar_csv
 from .json_utils import cargar_json
 from .excel_utils import leer_excel
+from .html_utils import cargar_html
 
 
 def cargar_archivo(nombre_archivo):
     """Cargar un archivo según su extensión."""
     extension = os.path.splitext(nombre_archivo)[1].lower()
+    ruta_archivo = os.path.abspath(nombre_archivo)
     if extension == ".csv":
-        return cargar_csv(nombre_archivo)
+        return cargar_csv(ruta_archivo)
     if extension == ".json":
-        return cargar_json(nombre_archivo)
+        return cargar_json(ruta_archivo)
     if extension in [".xls", ".xlsx"]:
-        return leer_excel(nombre_archivo)
+        return leer_excel(ruta_archivo)
+    if extension in [".htm", ".html"]:
+        return cargar_html(ruta_archivo)
+    if extension == ".parquet":
+        return pd.read_parquet(ruta_archivo)
+    if extension == ".h5":
+        return pd.read_hdf(ruta_archivo)
+    if extension == ".feather":
+        return pd.read_feather(ruta_archivo)
+    if extension == ".pkl":
+        return pd.read_pickle(ruta_archivo)
+    if extension == ".dta":
+        return pd.read_stata(ruta_archivo)
+    if extension == ".sav":
+        return pd.read_spss(ruta_archivo)
     raise ValueError(f"Formato de archivo no soportado: {extension}")
 

--- a/formulas/html_utils.py
+++ b/formulas/html_utils.py
@@ -1,0 +1,35 @@
+"""Funciones para trabajar con archivos o URLs de HTML."""
+
+import os
+import pandas as pd
+
+
+def cargar_html(fuente):
+    """Cargar tablas de una URL o archivo HTML.
+
+    Devuelve una lista de DataFrames con las tablas encontradas.
+    """
+    try:
+        if fuente.startswith("http://") or fuente.startswith("https://"):
+            print(f"Cargando tablas desde la URL: {fuente}")
+            dfs = pd.read_html(fuente)
+        else:
+            ruta_archivo = os.path.abspath(fuente)
+            nombre_archivo_simple = os.path.basename(ruta_archivo)
+            print(f"Cargando tablas desde el archivo: {nombre_archivo_simple}")
+            dfs = pd.read_html(ruta_archivo)
+
+        print(f"\nNúmero de tablas encontradas: {len(dfs)}")
+        for i, df in enumerate(dfs):
+            print(f"\nTabla {i+1}:")
+            print(df.head())
+        return dfs
+
+    except FileNotFoundError:
+        print(f"Error: No se pudo encontrar el archivo '{fuente}'")
+    except ValueError:
+        print(
+            f"Error: No se pudo cargar la fuente '{fuente}'. Verifique si contiene tablas HTML válidas."
+        )
+    except Exception as e:
+        print(f"Error al cargar la fuente: {str(e)}")


### PR DESCRIPTION
## Summary
- extend Excel utilities with `cargar_excel`
- add new `html_utils` module to load HTML tables
- expand `cargar_archivo` to handle more formats and HTML
- expose new utilities via `formulas.__init__`

## Testing
- `python -m py_compile $(git ls-files "*.py")`

------
https://chatgpt.com/codex/tasks/task_e_68493f537ed88322a6a0964196d186f6