### PR TITLE
Improve error handling for CSV and JSON loaders

### DIFF
--- a/formulas/csv_utils.py
+++ b/formulas/csv_utils.py
@@ -25,14 +25,26 @@ def cargar_csv(nombre_archivo: Union[str, os.PathLike]) -> pd.DataFrame:
     Archivo CSV cargado: datos.csv
     >>> df.head()
     """
-    ruta_archivo = os.path.abspath(nombre_archivo)
-    df = pd.read_csv(ruta_archivo)
-    print(f"Archivo CSV cargado: {os.path.basename(ruta_archivo)}")
-    print("\nPrimeras filas del dataset:")
-    print(df.head())
-    print("\nResumen estadístico del DataFrame:")
-    print(df.describe())
-    return df
+    try:
+        ruta_archivo = os.path.abspath(nombre_archivo)
+        nombre_archivo_simple = os.path.basename(ruta_archivo)
+        df = pd.read_csv(ruta_archivo)
+        print(f"Archivo CSV cargado: {nombre_archivo_simple}")
+        print("\nPrimeras filas del dataset:")
+        print(df.head())
+        print("\nResumen estadístico del DataFrame:")
+        print(df.describe())
+        return df
+    except FileNotFoundError:
+        print(f"Error: No se pudo encontrar el archivo '{nombre_archivo}'")
+    except pd.errors.EmptyDataError:
+        print(f"Error: El archivo '{nombre_archivo}' está vacío")
+    except ValueError:
+        print(
+            f"Error: No se pudo cargar el archivo '{nombre_archivo}'. Verifique si el archivo está en formato CSV válido."
+        )
+    except Exception as e:
+        print(f"Error al cargar el archivo: {str(e)}")
 
 
 def limpiar_columnas(df: pd.DataFrame) -> pd.DataFrame:

--- a/formulas/json_utils.py
+++ b/formulas/json_utils.py
@@ -3,6 +3,7 @@
 from typing import Union
 
 import os
+import json
 import pandas as pd
 
 
@@ -23,13 +24,27 @@ def cargar_json(nombre_archivo: Union[str, os.PathLike]) -> pd.DataFrame:
     --------
     >>> df = cargar_json("datos.json")
     """
-    ruta_archivo = os.path.abspath(nombre_archivo)
-    df = pd.read_json(ruta_archivo)
-    print(f"Archivo JSON cargado: {os.path.basename(ruta_archivo)}")
-    print("\nPrimeras filas del dataset:")
-    print(df.head())
-    print("\nResumen estadístico del DataFrame:")
-    print(df.describe())
-    return df
+    try:
+        ruta_archivo = os.path.abspath(nombre_archivo)
+        nombre_archivo_simple = os.path.basename(ruta_archivo)
+        df = pd.read_json(ruta_archivo)
+        print(f"Archivo JSON cargado: {nombre_archivo_simple}")
+        print("\nPrimeras filas del dataset:")
+        print(df.head())
+        print("\nResumen estadístico del DataFrame:")
+        print(df.describe())
+        return df
+    except FileNotFoundError:
+        print(f"Error: No se pudo encontrar el archivo '{nombre_archivo}'")
+    except ValueError:
+        print(
+            f"Error: No se pudo cargar el archivo '{nombre_archivo}'. Verifique si el archivo está en formato JSON válido o no está vacío."
+        )
+    except json.JSONDecodeError:
+        print(
+            f"Error: No se pudo analizar el archivo '{nombre_archivo}'. Verifique que el contenido tenga un formato JSON válido."
+        )
+    except Exception as e:
+        print(f"Error al cargar el archivo: {str(e)}")
 
 


### PR DESCRIPTION
## Summary
- add try/except to `cargar_csv` and `cargar_json`
- provide informative messages when files do not exist, are empty, or have invalid format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a94d62208322b38bff277941b828