### PR TITLE
Add histogram and boxplot visualization helpers

### DIFF
--- a/formulas/__init__.py
+++ b/formulas/__init__.py
@@ -33,6 +33,8 @@ from .visualizaciones import (
     relaciones_vs_target,
     represento_doble_hist,
     hist_pos_neg_feat,
+    histogramas_df,
+    boxplot_variables,
 )
 from .file_utils import cargar_archivo
 from .html_utils import cargar_html
@@ -73,5 +75,7 @@ __all__ = [
     "relaciones_vs_target",
     "represento_doble_hist",
     "hist_pos_neg_feat",
+    "histogramas_df",
+    "boxplot_variables",
 ]
 

--- a/formulas/visualizaciones.py
+++ b/formulas/visualizaciones.py
@@ -265,4 +265,56 @@ def hist_pos_neg_feat(
         )
 
 
+def histogramas_df(df: pd.DataFrame, bins: int = 30) -> None:
+    """Representar histogramas de todas las columnas de ``df``.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Conjunto de datos completo, incluida la variable objetivo.
+    bins : int, optional
+        Número de divisiones (bins) del histograma.
+
+    Examples
+    --------
+    >>> histogramas_df(df)
+    """
+
+    fig_por_fila = 5
+    tamanio_fig = 4
+    num_cols = len(df.columns)
+    num_filas = int(np.ceil(num_cols / fig_por_fila))
+    plt.figure(figsize=(fig_por_fila * tamanio_fig + 3, num_filas * tamanio_fig + 3))
+    for i, column in enumerate(df.columns, 1):
+        plt.subplot(num_filas, fig_por_fila, i)
+        sns.histplot(df[column], bins=bins)
+        plt.title(f"Distribuci\u00f3n var {column}")
+    plt.tight_layout()
+    plt.show()
+
+
+def boxplot_variables(x: pd.DataFrame, rotacion: int = 90) -> None:
+    """Mostrar un boxplot de todas las variables de ``x``.
+
+    Parameters
+    ----------
+    x : pandas.DataFrame
+        Variables independientes ya normalizadas.
+    rotacion : int, optional
+        Grados de rotaci\u00f3n para las etiquetas del eje X.
+
+    Examples
+    --------
+    >>> boxplot_variables(X_train)
+    """
+
+    plt.figure(figsize=(15, 7))
+    ax = sns.boxplot(data=x)
+    ax.set_xticklabels(ax.get_xticklabels(), rotation=rotacion)
+    plt.title("Representaci\u00f3n de cajas de las variables independientes X")
+    plt.ylabel("Valor de la variable normalizada")
+    plt.xlabel("Nombre de la variable")
+    plt.tight_layout()
+    plt.show()
+
 


### PR DESCRIPTION
## Summary
- extend visualization module with histogram and boxplot helpers
- expose new functions via package init

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m compileall -q -f $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6849b314563c8322ab4482b4c54c12a7