### PR TITLE
Add classification utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,28 @@ X_train, scaler = estandarizar_datos(X_train)
 X_test[scaler.feature_names_in_] = scaler.transform(X_test[scaler.feature_names_in_])
 ```
 
+## Modelos de clasificación
+
+Para entrenar y evaluar modelos de clasificación se incluyen utilidades para
+regresión logística, redes neuronales (*MLPClassifier*) y bosques aleatorios.
+Al evaluar un modelo se muestran automáticamente la matriz de confusión y la
+curva ROC junto con métricas de *precision*, *recall* y *accuracy*.
+
+```python
+from formulas import (
+    entrenar_regresion_logistica,
+    entrenar_mlp,
+    entrenar_random_forest,
+    evaluar_modelo,
+    dividir_train_test,
+)
+
+X_train, X_test, y_train, y_test = dividir_train_test(df, "objetivo")
+modelo = entrenar_regresion_logistica(X_train, y_train)
+metricas = evaluar_modelo(modelo, X_test, y_test)
+print(metricas)
+```
+
+De forma análoga pueden usarse `entrenar_mlp` o `entrenar_random_forest`
+pasando los parámetros deseados.
+

--- a/formulas/__init__.py
+++ b/formulas/__init__.py
@@ -39,6 +39,12 @@ from .visualizaciones import (
 from .file_utils import cargar_archivo
 from .html_utils import cargar_html
 from .model_utils import dividir_train_test, estandarizar_datos
+from .modelos import (
+    entrenar_regresion_logistica,
+    entrenar_mlp,
+    entrenar_random_forest,
+    evaluar_modelo,
+)
 
 __all__ = [
     "__version__",
@@ -80,5 +86,9 @@ __all__ = [
     "estandarizar_datos",
     "histogramas_df",
     "boxplot_variables",
+    "entrenar_regresion_logistica",
+    "entrenar_mlp",
+    "entrenar_random_forest",
+    "evaluar_modelo",
 ]
 

--- a/formulas/modelos.py
+++ b/formulas/modelos.py
@@ -1,0 +1,198 @@
+"""Modelos de clasificación comunes y utilidades de evaluación."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence, Any
+
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+from sklearn.linear_model import LogisticRegression
+from sklearn.neural_network import MLPClassifier
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import (
+    accuracy_score,
+    precision_score,
+    recall_score,
+    classification_report,
+    confusion_matrix,
+    RocCurveDisplay,
+)
+
+
+def entrenar_regresion_logistica(
+    X_train: pd.DataFrame,
+    y_train: pd.Series,
+    **kwargs: Any,
+) -> LogisticRegression:
+    """Entrenar un modelo de regresión logística.
+
+    Parameters
+    ----------
+    X_train : pandas.DataFrame
+        Variables de entrenamiento.
+    y_train : pandas.Series
+        Variable objetivo.
+    **kwargs : dict, optional
+        Parámetros adicionales para ``LogisticRegression``.
+
+    Returns
+    -------
+    sklearn.linear_model.LogisticRegression
+        Modelo ajustado.
+
+    Examples
+    --------
+    >>> model = entrenar_regresion_logistica(X_train, y_train)
+    """
+    model = LogisticRegression(**kwargs)
+    model.fit(X_train, y_train)
+    return model
+
+
+def entrenar_mlp(
+    X_train: pd.DataFrame,
+    y_train: pd.Series,
+    hidden_layer_sizes: Sequence[int] = (100,),
+    random_state: Optional[int] = None,
+    **kwargs: Any,
+) -> MLPClassifier:
+    """Entrenar un ``MLPClassifier`` de scikit-learn.
+
+    Parameters
+    ----------
+    X_train : pandas.DataFrame
+        Variables de entrenamiento.
+    y_train : pandas.Series
+        Variable objetivo.
+    hidden_layer_sizes : sequence of int, optional
+        Estructura de capas ocultas.
+    random_state : int, optional
+        Semilla para la aleatoriedad.
+    **kwargs : dict, optional
+        Parámetros adicionales para ``MLPClassifier``.
+
+    Returns
+    -------
+    sklearn.neural_network.MLPClassifier
+        Modelo ajustado.
+
+    Examples
+    --------
+    >>> model = entrenar_mlp(X_train, y_train, hidden_layer_sizes=(50, 50))
+    """
+    model = MLPClassifier(
+        hidden_layer_sizes=hidden_layer_sizes,
+        random_state=random_state,
+        **kwargs,
+    )
+    model.fit(X_train, y_train)
+    return model
+
+
+def entrenar_random_forest(
+    X_train: pd.DataFrame,
+    y_train: pd.Series,
+    n_estimators: int = 100,
+    random_state: Optional[int] = None,
+    **kwargs: Any,
+) -> RandomForestClassifier:
+    """Entrenar un ``RandomForestClassifier``.
+
+    Parameters
+    ----------
+    X_train : pandas.DataFrame
+        Variables de entrenamiento.
+    y_train : pandas.Series
+        Variable objetivo.
+    n_estimators : int, optional
+        Número de árboles del bosque.
+    random_state : int, optional
+        Semilla para la aleatoriedad.
+    **kwargs : dict, optional
+        Parámetros adicionales para ``RandomForestClassifier``.
+
+    Returns
+    -------
+    sklearn.ensemble.RandomForestClassifier
+        Modelo ajustado.
+
+    Examples
+    --------
+    >>> model = entrenar_random_forest(X_train, y_train, n_estimators=200)
+    """
+    model = RandomForestClassifier(
+        n_estimators=n_estimators,
+        random_state=random_state,
+        **kwargs,
+    )
+    model.fit(X_train, y_train)
+    return model
+
+
+def evaluar_modelo(
+    model: Any,
+    X_test: pd.DataFrame,
+    y_test: pd.Series,
+    titulo: str = "",
+) -> dict[str, float]:
+    """Calcular métricas y mostrar gráficas de evaluación.
+
+    Se imprime el ``classification_report`` y se representan la matriz de
+    confusión y la curva ROC (si es un problema binario).
+
+    Parameters
+    ----------
+    model : estimador de scikit-learn
+        Modelo previamente entrenado.
+    X_test : pandas.DataFrame
+        Variables de prueba.
+    y_test : pandas.Series
+        Valores reales de la variable objetivo.
+    titulo : str, optional
+        Texto a añadir al título de las gráficas.
+
+    Returns
+    -------
+    dict[str, float]
+        Diccionario con ``accuracy``, ``precision`` y ``recall``.
+
+    Examples
+    --------
+    >>> metricas = evaluar_modelo(modelo, X_test, y_test)
+    """
+    y_pred = model.predict(X_test)
+    if hasattr(model, "predict_proba"):
+        y_prob = model.predict_proba(X_test)[:, 1]
+    else:
+        y_prob = None
+
+    # Matriz de confusión
+    cm = confusion_matrix(y_test, y_pred)
+    sns.heatmap(cm, annot=True, fmt="d", cmap="Blues")
+    plt.title("Matriz de Confusión" + (f" - {titulo}" if titulo else ""))
+    plt.xlabel("Predicho")
+    plt.ylabel("Real")
+    plt.tight_layout()
+    plt.show()
+
+    # Curva ROC solo para binario
+    if y_prob is not None and len(set(y_test)) == 2:
+        RocCurveDisplay.from_predictions(y_test, y_prob)
+        plt.title("Curva ROC" + (f" - {titulo}" if titulo else ""))
+        plt.tight_layout()
+        plt.show()
+
+    precision = precision_score(
+        y_test, y_pred, average="binary" if len(set(y_test)) == 2 else "weighted"
+    )
+    recall = recall_score(
+        y_test, y_pred, average="binary" if len(set(y_test)) == 2 else "weighted"
+    )
+    accuracy = accuracy_score(y_test, y_pred)
+
+    print("\nReporte de clasificación:\n")
+    print(classification_report(y_test, y_pred))
+
+    return {"accuracy": accuracy, "precision": precision, "recall": recall}


### PR DESCRIPTION
## Summary
- add new `modelos` module with logistic regression, MLP and random forest helpers
- include `evaluar_modelo` to display confusion matrix and ROC curve
- export the new functions in `__init__`
- document usage in the README

## Testing
- `pip install -e .`
- `python -m py_compile formulas/modelos.py formulas/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6849b6f4e3f08322b04e683ccdd6aeaa