### PR TITLE
Simplifica lectura de datos con parámetro imprimir y **kwargs

### DIFF
--- a/etl_utils.py
+++ b/etl_utils.py
@@ -10,7 +10,7 @@ from typing import Union
 from formulas import (
     cargar_csv,
     cargar_json,
-    leer_excel,
+    cargar_excel,
     nulos,
     describir_columnas,
     matriz_correlacion,
@@ -25,5 +25,5 @@ def cargar_archivo(nombre_archivo: Union[str, os.PathLike]):
     if extension == ".json":
         return cargar_json(nombre_archivo)
     if extension in [".xls", ".xlsx"]:
-        return leer_excel(nombre_archivo)
+        return cargar_excel(nombre_archivo)
     raise ValueError(f"Formato de archivo no soportado: {extension}")

--- a/formulas/csv_utils.py
+++ b/formulas/csv_utils.py
@@ -6,8 +6,10 @@ import os
 import pandas as pd
 
 
-def cargar_csv(nombre_archivo: Union[str, os.PathLike]) -> pd.DataFrame:
-    """Cargar un archivo CSV y mostrar un resumen inicial.
+def cargar_csv(
+    nombre_archivo: Union[str, os.PathLike], imprimir: bool = True, **kwargs
+) -> pd.DataFrame:
+    """Cargar un archivo CSV.
 
     Parameters
     ----------
@@ -28,12 +30,14 @@ def cargar_csv(nombre_archivo: Union[str, os.PathLike]) -> pd.DataFrame:
     try:
         ruta_archivo = os.path.abspath(nombre_archivo)
         nombre_archivo_simple = os.path.basename(ruta_archivo)
-        df = pd.read_csv(ruta_archivo)
-        print(f"Archivo CSV cargado: {nombre_archivo_simple}")
-        print("\nPrimeras filas del dataset:")
-        print(df.head())
-        print("\nResumen estadístico del DataFrame:")
-        print(df.describe())
+        df = pd.read_csv(ruta_archivo, **kwargs)
+        if imprimir:
+            print(f"Archivo CSV cargado: {nombre_archivo_simple}")
+            print(f"Forma del DataFrame: {df.shape}")
+            print("\nPrimeras filas del dataset:")
+            print(df.head())
+            print("\nTipos de datos:")
+            print(df.dtypes)
         return df
     except FileNotFoundError:
         print(f"Error: No se pudo encontrar el archivo '{nombre_archivo}'")

--- a/formulas/excel_utils.py
+++ b/formulas/excel_utils.py
@@ -6,36 +6,13 @@ import os
 import pandas as pd
 
 
-def leer_excel(ruta_archivo: Union[str, os.PathLike], hoja: Optional[str] = None) -> pd.DataFrame:
-    """Leer un archivo de Excel y devolver un :class:`pandas.DataFrame`.
-
-    Parameters
-    ----------
-    ruta_archivo : str or PathLike
-        Ruta del archivo a leer.
-    hoja : str, optional
-        Nombre de la hoja a cargar. Si se omite se lee la primera.
-
-    Returns
-    -------
-    pandas.DataFrame
-        Datos del archivo Excel.
-
-    Examples
-    --------
-    >>> df = leer_excel("archivo.xlsx", hoja="Datos")
-    >>> len(df)
-    10
-    """
-    if hoja:
-        df = pd.read_excel(ruta_archivo, sheet_name=hoja)
-    else:
-        df = pd.read_excel(ruta_archivo)
-    return df
-
-
-def cargar_excel(nombre_archivo: Union[str, os.PathLike], hoja: Optional[str] = None) -> pd.DataFrame:
-    """Cargar un archivo de Excel e imprimir un resumen.
+def cargar_excel(
+    nombre_archivo: Union[str, os.PathLike],
+    hoja: Optional[str] = None,
+    imprimir: bool = True,
+    **kwargs,
+) -> pd.DataFrame:
+    """Cargar un archivo de Excel.
 
     Parameters
     ----------
@@ -58,15 +35,17 @@ def cargar_excel(nombre_archivo: Union[str, os.PathLike], hoja: Optional[str] = 
         ruta_archivo = os.path.abspath(nombre_archivo)
         nombre_archivo_simple = os.path.basename(ruta_archivo)
         if hoja:
-            df = pd.read_excel(ruta_archivo, sheet_name=hoja)
+            df = pd.read_excel(ruta_archivo, sheet_name=hoja, **kwargs)
         else:
-            df = pd.read_excel(ruta_archivo)
+            df = pd.read_excel(ruta_archivo, **kwargs)
 
-        print(f"Archivo Excel cargado: {nombre_archivo_simple}")
-        print("\nPrimeras filas del dataset:")
-        print(df.head())
-        print("\nResumen estadístico del DataFrame:")
-        print(df.describe())
+        if imprimir:
+            print(f"Archivo Excel cargado: {nombre_archivo_simple}")
+            print(f"Forma del DataFrame: {df.shape}")
+            print("\nPrimeras filas del dataset:")
+            print(df.head())
+            print("\nTipos de datos:")
+            print(df.dtypes)
         return df
     except FileNotFoundError:
         print(
@@ -78,6 +57,10 @@ def cargar_excel(nombre_archivo: Union[str, os.PathLike], hoja: Optional[str] = 
         )
     except Exception as e:
         print(f"Error al cargar el archivo: {str(e)}")
+
+
+# Alias para mantener compatibilidad con versiones anteriores
+leer_excel = cargar_excel
 
 
 def escribir_excel(df: pd.DataFrame, ruta_archivo: Union[str, os.PathLike], hoja: str = "Sheet1") -> None:

--- a/formulas/file_utils.py
+++ b/formulas/file_utils.py
@@ -5,7 +5,7 @@ import pandas as pd
 from typing import Union
 from .csv_utils import cargar_csv
 from .json_utils import cargar_json
-from .excel_utils import leer_excel
+from .excel_utils import cargar_excel
 from .html_utils import cargar_html
 
 
@@ -33,7 +33,7 @@ def cargar_archivo(nombre_archivo: Union[str, os.PathLike]) -> pd.DataFrame:
     if extension == ".json":
         return cargar_json(ruta_archivo)
     if extension in [".xls", ".xlsx"]:
-        return leer_excel(ruta_archivo)
+        return cargar_excel(ruta_archivo)
     if extension in [".htm", ".html"]:
         return cargar_html(ruta_archivo)
     if extension == ".parquet":

--- a/formulas/html_utils.py
+++ b/formulas/html_utils.py
@@ -6,7 +6,9 @@ import os
 import pandas as pd
 
 
-def cargar_html(fuente: Union[str, os.PathLike]) -> List[pd.DataFrame]:
+def cargar_html(
+    fuente: Union[str, os.PathLike], imprimir: bool = True, **kwargs
+) -> List[pd.DataFrame]:
     """Cargar tablas de una URL o archivo HTML.
 
     Parameters
@@ -25,18 +27,23 @@ def cargar_html(fuente: Union[str, os.PathLike]) -> List[pd.DataFrame]:
     """
     try:
         if fuente.startswith("http://") or fuente.startswith("https://"):
-            print(f"Cargando tablas desde la URL: {fuente}")
-            dfs = pd.read_html(fuente)
+            if imprimir:
+                print(f"Cargando tablas desde la URL: {fuente}")
+            dfs = pd.read_html(fuente, **kwargs)
         else:
             ruta_archivo = os.path.abspath(fuente)
             nombre_archivo_simple = os.path.basename(ruta_archivo)
-            print(f"Cargando tablas desde el archivo: {nombre_archivo_simple}")
-            dfs = pd.read_html(ruta_archivo)
+            if imprimir:
+                print(f"Cargando tablas desde el archivo: {nombre_archivo_simple}")
+            dfs = pd.read_html(ruta_archivo, **kwargs)
 
-        print(f"\nNúmero de tablas encontradas: {len(dfs)}")
-        for i, df in enumerate(dfs):
-            print(f"\nTabla {i+1}:")
-            print(df.head())
+        if imprimir:
+            print(f"\nNúmero de tablas encontradas: {len(dfs)}")
+            for i, df in enumerate(dfs):
+                print(f"\nTabla {i+1} - forma: {df.shape}")
+                print(df.head())
+                print("Tipos de datos:")
+                print(df.dtypes)
         return dfs
 
     except FileNotFoundError:

--- a/formulas/json_utils.py
+++ b/formulas/json_utils.py
@@ -7,8 +7,10 @@ import json
 import pandas as pd
 
 
-def cargar_json(nombre_archivo: Union[str, os.PathLike]) -> pd.DataFrame:
-    """Leer un archivo JSON y mostrar un resumen.
+def cargar_json(
+    nombre_archivo: Union[str, os.PathLike], imprimir: bool = True, **kwargs
+) -> pd.DataFrame:
+    """Leer un archivo JSON.
 
     Parameters
     ----------
@@ -27,12 +29,14 @@ def cargar_json(nombre_archivo: Union[str, os.PathLike]) -> pd.DataFrame:
     try:
         ruta_archivo = os.path.abspath(nombre_archivo)
         nombre_archivo_simple = os.path.basename(ruta_archivo)
-        df = pd.read_json(ruta_archivo)
-        print(f"Archivo JSON cargado: {nombre_archivo_simple}")
-        print("\nPrimeras filas del dataset:")
-        print(df.head())
-        print("\nResumen estadístico del DataFrame:")
-        print(df.describe())
+        df = pd.read_json(ruta_archivo, **kwargs)
+        if imprimir:
+            print(f"Archivo JSON cargado: {nombre_archivo_simple}")
+            print(f"Forma del DataFrame: {df.shape}")
+            print("\nPrimeras filas del dataset:")
+            print(df.head())
+            print("\nTipos de datos:")
+            print(df.dtypes)
         return df
     except FileNotFoundError:
         print(f"Error: No se pudo encontrar el archivo '{nombre_archivo}'")


### PR DESCRIPTION
## Summary
- unify CSV/Excel/JSON/HTML loaders with optional printing
- allow arbitrary `pandas.read_*` arguments via `**kwargs`
- update helper modules that relied on previous names

## Testing
- `python -m py_compile formulas/csv_utils.py formulas/json_utils.py formulas/excel_utils.py formulas/html_utils.py formulas/file_utils.py etl_utils.py formulas/__init__.py`
- `python -m compileall -q formulas etl_utils.py`
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad93ebcb88322971a4ef54bde91d0