### PR TITLE
Fix cargar_csv print mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ df = cargar_csv("datos.csv")
 resumen = nulos(df)
 df = convertir_a_datetime(df, "fecha")
 grafico_lineas(df, "fecha", "ventas", titulo="Ventas diarias")
+
+# Forzar la salida con ``print`` incluso fuera de un notebook
+df_print = cargar_csv("datos.csv", modo="print")
 ```
 
 grafico_barras(df, "producto", "ventas")


### PR DESCRIPTION
## Summary
- improve `cargar_csv` to accept `modo` case-insensitively and pass extra `read_csv` kwargs
- document forcing print mode in README

## Testing
- `python -m py_compile formulas/csv_utils.py`
- `python - <<'PY'
from formulas.csv_utils import cargar_csv
with open('test.csv','w') as f: f.write('a,b\n1,2')
print('modo print:'); cargar_csv('test.csv', modo='print')
print('modo logger:'); cargar_csv('test.csv', modo='logger')
print('modo auto:'); cargar_csv('test.csv', modo='invalid', imprimir=False)
print('done')
PY`

------
https://chatgpt.com/codex/tasks/task_e_684c00bb24588322bfdd90c1ca12baf6